### PR TITLE
Fix GitHub Pages deployment issue

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,11 +33,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
-          path: '.'
+          path: 'dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "/forge-web/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
Fixes #1

Update the `index.html`, `vite.config.ts`, and `.github/workflows/static.yml` files to fix the issue of the GitHub Pages site displaying a blank page.

* **index.html**
  - Change the `src` attribute of the script tag to use a relative path `./src/main.tsx`.

* **vite.config.ts**
  - Add the `base` property to the `defineConfig` function with the value `"/forge-web/"`.

* **.github/workflows/static.yml**
  - Add a step to run the build script before uploading the artifact.
  - Change the `path` attribute in the `Upload artifact` step to `dist`.

