### PR TITLE
Fix GitHub Pages 404 error

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
-    <script type="module" src="./src/main.tsx"></script>
+    <script type="module" src="/forge-web/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -79,5 +79,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
-  }
+  },
+  "homepage": "https://chanchal-d.github.io/forge-web/"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename="/forge-web/">
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}


### PR DESCRIPTION
Fixes #3

Fix GitHub Pages 404 error by updating configuration and paths.

* **package.json**: Add `homepage` field with the URL "https://chanchal-d.github.io/forge-web/".
* **src/App.tsx**: Add `basename` prop to `BrowserRouter` with the value "/forge-web/".
* **index.html**: Update the script tag for `main.tsx` to use the path "/forge-web/src/main.tsx".

