### PR TITLE
Fix Vite build failing due to Rollup import resolution error

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
-    <script type="module" src="/forge-web/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #5

Update the `index.html` file to fix the Vite build issue.

* Change the `src` attribute of the script tag to `./src/main.tsx` from `/forge-web/src/main.tsx`.

