### PR TITLE
Fix Vite build: Add missing output directory (dist)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ import { componentTagger } from "lovable-tagger";
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   base: "/forge-web/",
+  build: {
+    outDir: "dist", // Ensure build output goes here
+  },
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
Fixes #7

Add missing output directory to Vite build configuration.

* Modify `vite.config.ts` to include `build` section with `outDir: "dist"` under the `defineConfig` function.
* Ensure the `build` section is placed under the `base` section.

